### PR TITLE
Changing the upload example to use Kernal#at_exit instead of capistrano's :exit callback

### DIFF
--- a/examples/upload.rb
+++ b/examples/upload.rb
@@ -1,3 +1,6 @@
-on :exit do
+#you can use capistrano's built-in :exit callback, however this will not be triggered
+#when a task encounters an exception during execution. If you want to upload the log 
+#regardless of whether the task completed successfully or not then you must use Kernal#at_exit
+at_exit do
   put full_log, "#{deploy_to}/deploy.log"
 end


### PR DESCRIPTION
This is the only way to ensure that a log is uploaded when a task encounters an exception during execution
