### PR TITLE
Fix: encoding issues — incompatible character encodings: ASCII-8BIT a…

### DIFF
--- a/lib/capistrano/log_with_awesome.rb
+++ b/lib/capistrano/log_with_awesome.rb
@@ -23,6 +23,7 @@ module Capistrano
     def log(level, message, line_prefix=nil)
       if level <= self.level
         indent = "%*s" % [Capistrano::Logger::MAX_LEVEL, "*" * (Capistrano::Logger::MAX_LEVEL - level)]
+        message.force_encoding(Encoding.default_external ? Encoding.default_external : 'UTF-8')
         (RUBY_VERSION >= "1.9" ? message.lines : message).each do |line|
           if line_prefix
             self.class.log_with_awesome "#{indent} [#{line_prefix}] #{line.strip}"


### PR DESCRIPTION
Hello,

I discovered an issue using your gem not directly but your gem is used by a dependency which is capistrano-slack.

It seems that if we have a string with accent like "Chât Wéééb Test" in a puts, it raises an error on the line 5, here:
```ruby
    def self.log_with_awesome(message)
      @buffer ||= []
      @buffer << message
      @config.set :message, message
      @config.set :full_log, @buffer.join("\n")
      @config.silently_trigger(:log_message)
    end
```

Because it can't join an array containing multiple encoding.
You can verify that by yourself by doing
```ruby
[ "Chât Wéééb Test".force_encoding('ASCII-8BIT'),  "BONjour Jérémy"].join
```
It will raise a
```ruby
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
from (pry):3:in `join'
```

So, is it possible to merge my changes plz?
Thanks a lot, have a nice day.